### PR TITLE
use any available version of react-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "react-native": ">=0.11.0"
   },
   "dependencies": {
-    "react-tools": "^0.13.3"
+    "react-tools": "*"
   }
 }


### PR DESCRIPTION
 to avoid naming collision .