### PR TITLE
Updated gms:play-services to be more specific on requiring only GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:0.14.+"
-    compile 'com.google.android.gms:play-services:8.1.0' // <- Add this line
+    compile 'com.google.android.gms:play-services-gcm:8.1.0' // <- Add this line
     compile project(':RNGcmAndroid')                     // <- Add this line
 }
 ```


### PR DESCRIPTION
This change is more specific & accurate for this library, as we only require GCM. Else, a user is required to install more packages than needed from 'Extras' in packages just to compile. 

This can also mislead some users (me as well) to put in 'multidex true' in their build.gradle which is discouraged, and also causes Android versions under 5.0 to crash upon boot.