### PR TITLE
Upgrade google services api to 0.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ https://github.com/oney/TestGcm
 
 - Run `npm install react-native-gcm-android --save`
 
-- In `android/build.gradle`
+- In `android/build.gradle`, **visit the [google-services repo](https://bintray.com/android/android-tools/com.google.gms.google-services/) for the latest version to use**
+
 ```gradle
 dependencies {
     classpath 'com.android.tools.build:gradle:1.3.1'
-    classpath 'com.google.gms:google-services:1.5.0-beta3' // <- Add this line
+    classpath 'com.google.gms:google-services:2.1.0-alpha3' // <- Add this line
 ```
 
 - In `android/settings.gradle`, add
@@ -35,7 +36,7 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:0.16.+"
-    compile 'com.google.android.gms:play-services-gcm:8.3.0' // <- Add this line
+    compile 'com.google.android.gms:play-services-gcm:8.4.0' // <- Add this line
     compile project(':RNGcmAndroid')                         // <- Add this line
     compile project(':react-native-system-notification')     // <- Add this line
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:0.17.+'
-    compile 'com.google.android.gms:play-services-gcm:8.1.0'
+    compile 'com.google.android.gms:play-services-gcm:8.4.0'
     compile 'com.android.support:appcompat-v7:23.0.0'
     compile project(':react-native-system-notification')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gcm-android",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oney/react-native-gcm-android.git"


### PR DESCRIPTION
This is to fix an issue when using this module with the latest [react-native-maps](https://github.com/lelandrichardson/react-native-maps).  It uses the latest google services api (0.8.4 as of writing).
- Update the README with new instructions on adding google services gcm
- Bump version to signify possible breaking change
