### PR TITLE
match the package version with npm published one (0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gcm-android",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oney/react-native-gcm-android.git"


### PR DESCRIPTION
The version of this published npm package is 0.2.0 while there is still 0.1.9 in the package.json.
