### PR TITLE
Update for compatibility with react-native-system-notification 0.2.0

### DIFF
--- a/android/src/main/java/com/oney/gcm/BackgroundService.java
+++ b/android/src/main/java/com/oney/gcm/BackgroundService.java
@@ -31,7 +31,7 @@ public class BackgroundService extends Service {
                 .setJSMainModuleName("index.android")
                 .addPackage(new MainReactPackage())
                 .addPackage(new GcmPackage(intent))
-                .addPackage(new NotificationPackage(null))
+                .addPackage(new NotificationPackage())
                 .setUseDeveloperSupport(getBuildConfigDEBUG())
                 .setInitialLifecycleState(LifecycleState.RESUMED)
                 .build();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gcm-android",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/oney/react-native-gcm-android.git"
@@ -16,7 +16,7 @@
     "GCM"
   ],
   "peerDependencies": {
-    "react-native": ">=0.11.0",
-    "react-native-system-notification": "^0.1.2"
+    "react-native": ">=0.29.0",
+    "react-native-system-notification": "^0.2.0"
   }
 }


### PR DESCRIPTION
[react-native-system-notification PR #55](https://github.com/Neson/react-native-system-notification/pull/55) merged for RN 0.29.0 compatibility. This PR makes some minor changes to maintain compatibility.

Version number updated to 0.2.0 so that ^0.1.9 continues to work with react-native-system-notification ^0.1.2.
