### PR TITLE
Fork oney/react-native-gcm-android to address background crash

### DIFF
--- a/android/src/main/java/com/oney/gcm/MainReactPackage.java
+++ b/android/src/main/java/com/oney/gcm/MainReactPackage.java
@@ -25,7 +25,7 @@ import com.facebook.react.views.scroll.ReactScrollViewManager;
 import com.facebook.react.views.swiperefresh.SwipeRefreshLayoutManager;
 import com.facebook.react.views.switchview.ReactSwitchManager;
 import com.facebook.react.views.text.ReactRawTextManager;
-import com.facebook.react.views.text.ReactTextInlineImageViewManager;
+//import com.facebook.react.views.text.ReactTextInlineImageViewManager;
 import com.facebook.react.views.text.ReactTextViewManager;
 import com.facebook.react.views.text.ReactVirtualTextViewManager;
 import com.facebook.react.views.textinput.ReactTextInputManager;
@@ -74,7 +74,7 @@ public class MainReactPackage implements ReactPackage {
                 new ReactToolbarManager(),
                 new ReactViewManager(),
                 new ReactViewPagerManager(),
-                new ReactTextInlineImageViewManager(),
+//                new ReactTextInlineImageViewManager(),
                 new ReactVirtualTextViewManager(),
                 new SwipeRefreshLayoutManager(),
                 new ReactWebViewManager());


### PR DESCRIPTION
Some research pointed to this oney/react-native-gcm-android/issues/37 matching the symptoms seen in #1434. This makes the first fork of a public repo we're doing, at Trabian's suggestion. There are still others in github.com/trabian that we should eventually dup/fork and switch to.
